### PR TITLE
Add useReducer hook and fix O(n²) unkeyed node lookup in reconciler

### DIFF
--- a/src/component.ts
+++ b/src/component.ts
@@ -73,7 +73,7 @@ export function render(parentElement: Element, newChildVNodes: VNode[], oldChild
         const keyMap: Record<string, [VNode, Node] | undefined> = {}
 
         // Node "pool" for reuse
-        const unkeyedNodes: Node[] = []
+        const unkeyedNodes = new Set<Node>()
 
         let anyKeyedNodes = false
 
@@ -123,12 +123,12 @@ export function render(parentElement: Element, newChildVNodes: VNode[], oldChild
                             for (let i = 0; i < nodes.length; i++) {
                                 const node = nodes.item(i)
                                 // if (elementContainsNode(parentElement, node)) {
-                                unkeyedNodes.push(node)
+                                unkeyedNodes.add(node)
                                 // }
                             }
                         }
                         else /*if (elementContainsNode(parentElement, oldDOMNode))*/ {
-                            unkeyedNodes.push(oldDOMNode)
+                            unkeyedNodes.add(oldDOMNode)
                         }
                     }
                 }
@@ -164,9 +164,10 @@ export function render(parentElement: Element, newChildVNodes: VNode[], oldChild
                         // unsetting the oldChildVNode will cause the DOM node to be appended
                         oldChildVNode = undefined
                     }
-                    else if (unkeyedNodes.length > 0) {
+                    else if (unkeyedNodes.size > 0) {
 
-                        const domNode = unkeyedNodes.shift()!
+                        const domNode = unkeyedNodes.values().next().value!
+                        unkeyedNodes.delete(domNode)
                         // ...reuse an old unkeyed node, if any available
                         oldChildVNode = {
                             _: VNodeType.Nothing,
@@ -228,10 +229,7 @@ export function render(parentElement: Element, newChildVNodes: VNode[], oldChild
                 }
 
                 // Remove the current DOM node from unkeyedNodes to make sure it's not reused!
-                const unkeyedIndex = unkeyedNodes.indexOf(domNodeAtIndex!)
-                if (unkeyedIndex >= 0) {
-                    unkeyedNodes.splice(unkeyedIndex, 1)
-                }
+                unkeyedNodes.delete(domNodeAtIndex!)
             }
 
             switch (newChildVNode._) {

--- a/src/component.ts
+++ b/src/component.ts
@@ -51,11 +51,15 @@ export function tryHandleComponentError(parentElement: Element, vNode: Component
 
         renderingContext = undefined
 
-        const errorView = vNode.errorHandler(err)
 
-        render(parentElement, [errorView], vNode.rendition === undefined ? [] : [vNode.rendition], isSvg)
-
-        vNode.rendition = errorView
+        try {
+            const errorView = vNode.errorHandler(err)
+            render(parentElement, [errorView], vNode.rendition === undefined ? [] : [vNode.rendition], isSvg)
+            vNode.rendition = errorView
+        } catch (handlerErr) {
+            console.error('An error occurred in the error handler: ' + handlerErr)
+            throw err
+        }
     } else {
         throw err
     }
@@ -991,7 +995,7 @@ function attemptEffectCleanup(t: EffectWrapper) {
         try {
             t.cleanup()
         } catch (err) {
-            console.error('An error occured during effect cleanup: ' + err)
+            console.error('An error occurred during effect cleanup: ' + err)
         }
         t.cleanup = undefined
     }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -193,6 +193,8 @@ export function useReducer<TState, TAction>(
     initialState: TState
 ): [TState, (action: TAction) => void] {
     const [state, setState] = useState(initialState)
-    const dispatch = useCallback((action: TAction) => setState(s => reducer(s, action)), [])
+    const reducerRef = useRef(reducer)
+    reducerRef.current = reducer
+    const dispatch = useCallback((action: TAction) => setState(s => reducerRef.current(s, action)), [])
     return [state, dispatch]
 }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -182,3 +182,17 @@ export function useMemo<TMemoization>(fn: () => TMemoization, deps: unknown[]): 
 export function useCallback<TCallback extends Function>(callback: TCallback, deps: unknown[]): TCallback {
     return useMemo(() => callback, deps)
 }
+
+/**
+ *
+ * @param reducer
+ * @param initialState
+ */
+export function useReducer<TState, TAction>(
+    reducer: (state: TState, action: TAction) => TState,
+    initialState: TState
+): [TState, (action: TAction) => void] {
+    const [state, setState] = useState(initialState)
+    const dispatch = useCallback((action: TAction) => setState(s => reducer(s, action)), [])
+    return [state, dispatch]
+}

--- a/test/hooks.spec.tsx
+++ b/test/hooks.spec.tsx
@@ -1,6 +1,6 @@
 import { render } from '../src/component'
 import { ComponentVNode, Ref } from '../src/contract'
-import { useCallback, useEffect, useErrorHandler, useLayoutEffect, useMemo, useRef, useState } from '../src/hooks'
+import { useCallback, useEffect, useErrorHandler, useLayoutEffect, useMemo, useReducer, useRef, useState } from '../src/hooks'
 import * as myra from '../src/myra'
 import { expect } from 'chai'
 import * as sinon from 'sinon'
@@ -810,5 +810,77 @@ describe('useCallback', () => {
         updateState(1)
         await tick()
         expect(renderCount).to.eq(1)
+    })
+})
+
+describe('useReducer', () => {
+    it('returns the initial state', () => {
+        let state: number | undefined
+
+        const Component = () => {
+            ;[state] = useReducer((s: number, a: number) => s + a, 0)
+            return <div />
+        }
+
+        render(document.body, [<Component />], [])
+        expect(state).to.eq(0)
+    })
+
+    it('updates state when an action is dispatched', async () => {
+        let dispatch!: (action: number) => void
+        let state: number | undefined
+
+        const Component = () => {
+            ;[state, dispatch] = useReducer((s: number, a: number) => s + a, 0)
+            return <div />
+        }
+
+        render(document.body, [<Component />], [])
+        dispatch(5)
+        await tick()
+        expect(state).to.eq(5)
+    })
+
+    it('returns a stable dispatch reference across renders', async () => {
+        const dispatches: ((action: number) => void)[] = []
+        let updateState: myra.Evolve<number> = () => 0
+
+        const Component = () => {
+            const [, setCount] = useState(0)
+            updateState = setCount
+            const [, dispatch] = useReducer((s: number, a: number) => s + a, 0)
+            dispatches.push(dispatch)
+            return <div />
+        }
+
+        render(document.body, [<Component />], [])
+        await tick()
+        updateState(1)
+        await tick()
+        expect(dispatches.length).to.eq(2)
+        expect(dispatches[0]).to.eq(dispatches[1])
+    })
+
+    it('always uses the latest reducer', async () => {
+        let dispatch!: (action: number) => void
+        let state: number | undefined
+        let multiplier = 1
+
+        const Component = () => {
+            ;[state, dispatch] = useReducer((s: number, a: number) => s + a * multiplier, 0)
+            return <div />
+        }
+
+        const vNode = <Component />
+        render(document.body, [vNode], [])
+        dispatch(2)
+        await tick()
+        expect(state).to.eq(2)
+
+        multiplier = 10
+        render(document.body, [<Component />], [vNode])
+        dispatch(2)
+        await tick()
+        expect(state).to.eq(22) // 2 + (2 * 10)
     })
 })


### PR DESCRIPTION
- Adds useReducer(reducer, initialState) hook — built on useState with a stable dispatch reference via useCallback

- Fixes an O(n²) performance bug in the reconciler: unkeyed node pool was an Array using indexOf + splice for removal, replaced with a Set for O(1) operations

- Guards errors thrown inside useErrorHandler callbacks (previously they'd swallow the original error); now logs the handler error and re-throws the original

- Fixes typo: "occured" → "occurred" in effect cleanup error message