### PR TITLE
Queued rendering

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,5 +1,6 @@
-import { getRenderingContext, renderComponent, tryHandleComponentError } from './component'
-import { ComponentProps, ComponentVNode, Context, ContextBinding, Effect, ErrorHandler, Evolve, Ref, UpdateState } from './contract'
+import { getRenderingContext, tryHandleComponentError } from './component'
+import { enqueueRender } from './queue'
+import { Context, ContextBinding, Effect, ErrorHandler, Evolve, Ref, UpdateState } from './contract'
 import { equal } from './helpers'
 import { ComponentLink, RenderNode } from './internal'
 
@@ -31,24 +32,7 @@ export function useState<TState>(initialState: TState | LazyStateInitialization<
 
                 currentRenderNode.data![hookIndex] = [update, evolve]
 
-                if (!currentRenderNode.debounceRender) {
-                    setTimeout(() => {
-                        link.renderNode.debounceRender = false
-
-                        const vNode = link.renderNode.vNode
-                        if (vNode !== undefined) {
-                            renderComponent(
-                                parentElement,
-                                link.renderNode.vNode as ComponentVNode<ComponentProps>,
-                                link.renderNode,
-                                link.renderNode.rendition,
-                                isSvg,
-                                false  // state-change re-render: never allow memo skip
-                            )
-                        }
-                    })
-                }
-                currentRenderNode.debounceRender = true
+                enqueueRender(parentElement, currentRenderNode, isSvg, false)
             } catch (err) {
                 setTimeout(() => {
                     tryHandleComponentError(parentElement, currentRenderNode, isSvg, err as Error)
@@ -247,16 +231,7 @@ function makeReRenderCallback(
         if (currentRenderNode.stale) {
             return
         }
-        if (!currentRenderNode.debounceRender) {
-            setTimeout(() => {
-                link.renderNode.debounceRender = false
-                const vNode = link.renderNode.vNode
-                if (vNode !== undefined) {
-                    renderComponent(parentElement, link.renderNode.vNode as ComponentVNode<ComponentProps>, link.renderNode, link.renderNode.rendition, isSvg, false)
-                }
-            })
-        }
-        currentRenderNode.debounceRender = true
+        enqueueRender(parentElement, currentRenderNode, isSvg, false)
     }
 }
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -32,7 +32,7 @@ export function useState<TState>(initialState: TState | LazyStateInitialization<
 
                 currentRenderNode.data![hookIndex] = [update, evolve]
 
-                enqueueRender(parentElement, currentRenderNode, isSvg, false)
+                enqueueRender(parentElement, currentRenderNode, isSvg)
             } catch (err) {
                 setTimeout(() => {
                     tryHandleComponentError(parentElement, currentRenderNode, isSvg, err as Error)
@@ -231,7 +231,7 @@ function makeReRenderCallback(
         if (currentRenderNode.stale) {
             return
         }
-        enqueueRender(parentElement, currentRenderNode, isSvg, false)
+        enqueueRender(parentElement, currentRenderNode, isSvg)
     }
 }
 

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -6,7 +6,6 @@ interface RenderQueueEntry {
     parentElement: Element
     renderNode: RenderNode
     isSvg: boolean
-    allowMemo: boolean
 }
 
 const renderQueue: RenderQueueEntry[] = []
@@ -15,11 +14,10 @@ let flushScheduled = false
 export function enqueueRender(
     parentElement: Element,
     renderNode: RenderNode,
-    isSvg: boolean,
-    allowMemo: boolean
+    isSvg: boolean
 ): void {
     if (!renderNode.debounceRender) {
-        renderQueue.push({ parentElement, renderNode, isSvg, allowMemo })
+        renderQueue.push({ parentElement, renderNode, isSvg })
         renderNode.debounceRender = true
     }
     if (!flushScheduled) {
@@ -34,6 +32,8 @@ function flushRenderQueue(): void {
     // (e.g. cascading setState) go into the next batch rather than this one.
     const batch = renderQueue.splice(0)
     for (const entry of batch) {
+        // Reset before rendering so any setState called during render can re-enqueue
+        // for the next batch (see splice(0) above).
         entry.renderNode.debounceRender = false
         const vNode = entry.renderNode.vNode
         if (vNode !== undefined) {
@@ -43,7 +43,8 @@ function flushRenderQueue(): void {
                 entry.renderNode,
                 entry.renderNode.rendition,
                 entry.isSvg,
-                entry.allowMemo
+                // allowMemo is always false for state-change re-renders
+                false
             )
         }
     }

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -1,0 +1,50 @@
+import { ComponentProps, ComponentVNode } from './contract'
+import { RenderNode } from './internal'
+import { renderComponent } from './component'
+
+interface RenderQueueEntry {
+    parentElement: Element
+    renderNode: RenderNode
+    isSvg: boolean
+    allowMemo: boolean
+}
+
+const renderQueue: RenderQueueEntry[] = []
+let flushScheduled = false
+
+export function enqueueRender(
+    parentElement: Element,
+    renderNode: RenderNode,
+    isSvg: boolean,
+    allowMemo: boolean
+): void {
+    if (!renderNode.debounceRender) {
+        renderQueue.push({ parentElement, renderNode, isSvg, allowMemo })
+        renderNode.debounceRender = true
+    }
+    if (!flushScheduled) {
+        flushScheduled = true
+        setTimeout(flushRenderQueue)
+    }
+}
+
+function flushRenderQueue(): void {
+    flushScheduled = false
+    // Snapshot and clear before flushing so renders triggered during the flush
+    // (e.g. cascading setState) go into the next batch rather than this one.
+    const batch = renderQueue.splice(0)
+    for (const entry of batch) {
+        entry.renderNode.debounceRender = false
+        const vNode = entry.renderNode.vNode
+        if (vNode !== undefined) {
+            renderComponent(
+                entry.parentElement,
+                vNode as ComponentVNode<ComponentProps>,
+                entry.renderNode,
+                entry.renderNode.rendition,
+                entry.isSvg,
+                entry.allowMemo
+            )
+        }
+    }
+}

--- a/test/renderer.spec.tsx
+++ b/test/renderer.spec.tsx
@@ -1793,7 +1793,8 @@ describe('batching', () => {
         renderCountA = 0
         renderCountB = 0
 
-        // Both siblings update in the same tick — should produce one render each
+        // Both siblings update in the same synchronous block — they share one
+        // setTimeout flush, so each renders exactly once (no duplicate renders).
         setA(1)
         setB(1)
         await tick()
@@ -1843,10 +1844,10 @@ describe('batching', () => {
 
         expect(document.getElementById('c1')!.textContent).to.eq('42')
         expect(document.getElementById('c2')!.textContent).to.eq('42')
-        // Each consumer renders exactly twice: once via synchronous tree-walk
-        // when the Provider re-renders, and once via the subscription callback.
-        // The batching ensures all subscription-triggered renders share one
-        // setTimeout flush rather than N separate flushes.
+        // Each consumer renders twice: once via the synchronous Provider tree-walk,
+        // and once via the context subscription callback. Both subscription callbacks
+        // are batched into the same setTimeout flush (rather than N separate flushes),
+        // so each consumer still renders exactly once from the subscription.
         expect(renderCountC1).to.eq(2)
         expect(renderCountC2).to.eq(2)
     })

--- a/test/renderer.spec.tsx
+++ b/test/renderer.spec.tsx
@@ -1758,3 +1758,128 @@ it('keeps focus of element when rendering keyed siblings', () => {
     expect(node).to.be.eq(document.activeElement as HTMLInputElement)
 })
 
+/**
+ * Shared-queue batching
+ */
+describe('batching', () => {
+
+    beforeEach(() => {
+        Array.prototype.slice.call(document.body.childNodes).forEach((c: Node) => document.body.removeChild(c))
+    })
+
+    it('batches sibling component renders into a single flush', async () => {
+        let renderCountA = 0
+        let renderCountB = 0
+        let setA: myra.Evolve<number> = () => 0
+        let setB: myra.Evolve<number> = () => 0
+
+        const A = () => {
+            const [n, set] = myra.useState(0)
+            setA = set
+            renderCountA++
+            return <span id="a">{n}</span>
+        }
+        const B = () => {
+            const [n, set] = myra.useState(0)
+            setB = set
+            renderCountB++
+            return <span id="b">{n}</span>
+        }
+        const Root = () => <div><A /><B /></div>
+
+        myra.mount(<Root />, document.body)
+        await tick()
+
+        renderCountA = 0
+        renderCountB = 0
+
+        // Both siblings update in the same tick — should produce one render each
+        setA(1)
+        setB(1)
+        await tick()
+
+        expect(renderCountA).to.eq(1)
+        expect(renderCountB).to.eq(1)
+        expect(document.getElementById('a')!.textContent).to.eq('1')
+        expect(document.getElementById('b')!.textContent).to.eq('1')
+    })
+
+    it('batches context fan-out: all consumers update in a single flush', async () => {
+        const Ctx = myra.createContext(0)
+        let renderCountC1 = 0
+        let renderCountC2 = 0
+        let setVal: myra.Evolve<number> = () => 0
+
+        const Consumer1 = () => {
+            renderCountC1++
+            const v = myra.useContext(Ctx)
+            return <span id="c1">{v}</span>
+        }
+        const Consumer2 = () => {
+            renderCountC2++
+            const v = myra.useContext(Ctx)
+            return <span id="c2">{v}</span>
+        }
+        const Provider = () => {
+            const [val, set] = myra.useState(0)
+            setVal = set
+            return (
+                <Ctx.Provider value={val}>
+                    <Consumer1 />
+                    <Consumer2 />
+                </Ctx.Provider>
+            )
+        }
+
+        myra.mount(<Provider />, document.body)
+        await tick()
+
+        renderCountC1 = 0
+        renderCountC2 = 0
+
+        setVal(42)
+        await tick()
+        await tick() // context notifications fire in a layout effect, need an extra tick
+
+        expect(document.getElementById('c1')!.textContent).to.eq('42')
+        expect(document.getElementById('c2')!.textContent).to.eq('42')
+        // Each consumer renders exactly twice: once via synchronous tree-walk
+        // when the Provider re-renders, and once via the subscription callback.
+        // The batching ensures all subscription-triggered renders share one
+        // setTimeout flush rather than N separate flushes.
+        expect(renderCountC1).to.eq(2)
+        expect(renderCountC2).to.eq(2)
+    })
+
+    it('defers cascading setState into the next batch', async () => {
+        let renderCount = 0
+        let triggerCascade: myra.Evolve<number> = () => 0
+
+        const Cascading = () => {
+            const [a, setA] = myra.useState(0)
+            const [b, setB] = myra.useState(0)
+            triggerCascade = setA
+            renderCount++
+            if (a > 0 && b === 0) {
+                setB(a * 2)
+            }
+            return <span id="cas">{a},{b}</span>
+        }
+
+        myra.mount(<Cascading />, document.body)
+        await tick()
+
+        renderCount = 0
+        triggerCascade(5)
+
+        // First tick: renders with a=5, b=0 — setB enqueued for next batch
+        await tick()
+        expect(renderCount).to.eq(1)
+
+        // Second tick: renders with a=5, b=10
+        await tick()
+        expect(renderCount).to.eq(2)
+        expect(document.getElementById('cas')!.textContent).to.eq('5,10')
+    })
+})
+


### PR DESCRIPTION
Extract shared render queue to batch async re-renders

Moves the debounced setState/context re-render scheduling out of hooks.tsinto a new queue.ts module. Multiple components triggering updates in the same tick now share a single setTimeout flush rather than scheduling independent timers, reducing redundant renders.